### PR TITLE
fix(android): hostname always equals IP

### DIFF
--- a/android/src/main/java/com/servicediscovery/ServiceDiscoveryModule.kt
+++ b/android/src/main/java/com/servicediscovery/ServiceDiscoveryModule.kt
@@ -159,10 +159,10 @@ class ServiceDiscoveryModule internal constructor(context: ReactApplicationConte
       service.putString("type", "$serviceType.")
       service.putString("domain", "local.")
       service.putInt("port", serviceInfo.port)
+      service.putString("hostName", serviceInfo.hostname)
 
       val host = serviceInfo.host
       if (host != null) {
-        service.putString("hostName", host.canonicalHostName)
         service.putArray("addresses", WritableNativeArray().apply {
           pushString(host.hostAddress)
         })


### PR DESCRIPTION
This will use the API36 method to retrieve the hostname, although only available in Android 16.

When I run `avahi-browse -rt _matter._tcp`, it returns:
```
= enp4s0 IPv6 C972B38D89A8A4CE-0000000000000008             _matter._tcp         local
   hostname = [4CEBD6477484.local]
   address = [192.168.1.14]
   port = [5540]
   txt = ["="]
``` 
So, hostname should be `4CEBD6477484.local`, but I receive `192.168.1.14` instead.