### PR TITLE
fix(android): add resolve queue to handle NsdManager single-resolve limitation

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.2'
+        ruby-version: '3.3'
         bundler-cache: false
 
     - name: Cache dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         with:
           path: |
             **/ios/Pods
-          key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile.lock') }}
+          key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile.lock', 'yarn.lock', 'package.json') }}
           restore-keys: |
             ${{ runner.os }}-cocoapods-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
 
   build-ios:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       TURBO_CACHE_DIR: .turbo/ios
     steps:

--- a/android/src/main/java/com/servicediscovery/ServiceDiscoveryModule.kt
+++ b/android/src/main/java/com/servicediscovery/ServiceDiscoveryModule.kt
@@ -3,6 +3,8 @@ package com.servicediscovery
 import android.content.Context
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
@@ -12,6 +14,7 @@ import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import java.nio.charset.StandardCharsets
+import java.util.LinkedList
 
 
 class ServiceDiscoveryModule internal constructor(context: ReactApplicationContext) :
@@ -23,6 +26,21 @@ class ServiceDiscoveryModule internal constructor(context: ReactApplicationConte
 
   // Keep track of resolved services, because onServiceLost doesn't pass a resolved service
   private val resolvedServices: MutableMap<String, NsdServiceInfo> = HashMap()
+
+  // Resolve queue to handle Android's single-resolve limitation
+  private data class ResolveRequest(val service: NsdServiceInfo, var retryCount: Int = 0)
+  private val resolveQueue: LinkedList<ResolveRequest> = LinkedList()
+  private var isResolving: Boolean = false
+  private val mainHandler = Handler(Looper.getMainLooper())
+  private val pendingServices: MutableSet<String> = HashSet()
+
+  companion object {
+    private const val SERVICE_FOUND = "serviceFound"
+    private const val SERVICE_LOST = "serviceLost"
+    private const val MAX_RETRY_COUNT = 3
+    private const val RETRY_DELAY_MS = 100L
+    const val NAME = "ServiceDiscovery"
+  }
 
   override fun getName(): String {
     return NAME
@@ -42,6 +60,86 @@ class ServiceDiscoveryModule internal constructor(context: ReactApplicationConte
   override fun removeListeners(count: Double) {
   }
 
+  private fun queueServiceForResolve(service: NsdServiceInfo) {
+    val serviceKey = "${service.serviceName}-${service.serviceType}"
+    synchronized(resolveQueue) {
+      // Skip if already pending or resolved
+      if (pendingServices.contains(serviceKey) || resolvedServices.containsKey(service.serviceName)) {
+        return
+      }
+      pendingServices.add(serviceKey)
+      resolveQueue.add(ResolveRequest(service))
+      Log.d(NAME, "Queued service for resolve: ${service.serviceName} (queue size: ${resolveQueue.size})")
+    }
+    processResolveQueue()
+  }
+
+  private fun processResolveQueue() {
+    synchronized(resolveQueue) {
+      if (isResolving || resolveQueue.isEmpty()) {
+        return
+      }
+      isResolving = true
+    }
+
+    val request = synchronized(resolveQueue) { resolveQueue.poll() } ?: run {
+      synchronized(resolveQueue) { isResolving = false }
+      return
+    }
+
+    Log.d(NAME, "Resolving service: ${request.service.serviceName} (attempt ${request.retryCount + 1})")
+
+    try {
+      nsdManager.resolveService(request.service, object : NsdManager.ResolveListener {
+        override fun onServiceResolved(serviceInfo: NsdServiceInfo) {
+          try {
+            val serviceKey = "${serviceInfo.serviceName}-${serviceInfo.serviceType}"
+            synchronized(resolveQueue) {
+              pendingServices.remove(serviceKey)
+            }
+            resolvedServices[serviceInfo.serviceName] = serviceInfo
+            sendEvent(SERVICE_FOUND, serviceToMap(serviceInfo))
+            Log.d(NAME, "Resolved service: ${serviceInfo.serviceName}")
+          } catch (e: Exception) {
+            Log.e(NAME, "Error handling resolved service", e)
+          } finally {
+            synchronized(resolveQueue) { isResolving = false }
+            // Small delay before processing next to avoid overwhelming NsdManager
+            mainHandler.postDelayed({ processResolveQueue() }, 50)
+          }
+        }
+
+        override fun onResolveFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
+          Log.e(NAME, "Resolve failed for ${serviceInfo.serviceName}: errorCode=$errorCode")
+
+          val serviceKey = "${serviceInfo.serviceName}-${serviceInfo.serviceType}"
+
+          // Retry on FAILURE_ALREADY_ACTIVE (3) or other transient errors
+          if (request.retryCount < MAX_RETRY_COUNT) {
+            request.retryCount++
+            synchronized(resolveQueue) {
+              resolveQueue.add(request) // Re-queue for retry
+            }
+            Log.d(NAME, "Re-queued ${serviceInfo.serviceName} for retry (attempt ${request.retryCount})")
+          } else {
+            synchronized(resolveQueue) {
+              pendingServices.remove(serviceKey)
+            }
+            Log.e(NAME, "Giving up on ${serviceInfo.serviceName} after ${MAX_RETRY_COUNT} retries")
+          }
+
+          synchronized(resolveQueue) { isResolving = false }
+          // Longer delay after failure before retrying
+          mainHandler.postDelayed({ processResolveQueue() }, RETRY_DELAY_MS)
+        }
+      })
+    } catch (e: Exception) {
+      Log.e(NAME, "Exception starting resolve", e)
+      synchronized(resolveQueue) { isResolving = false }
+      mainHandler.postDelayed({ processResolveQueue() }, RETRY_DELAY_MS)
+    }
+  }
+
   @ReactMethod
   override fun startSearch(type: String, promise: Promise) {
     try {
@@ -55,38 +153,22 @@ class ServiceDiscoveryModule internal constructor(context: ReactApplicationConte
       val discoveryListener: NsdManager.DiscoveryListener =
         object : NsdManager.DiscoveryListener {
           override fun onDiscoveryStarted(regType: String) {
-            // Service discovery started
+            Log.d(NAME, "Discovery started for $regType")
           }
 
           override fun onDiscoveryStopped(regType: String) {
-            // Service discovery stopped
+            Log.d(NAME, "Discovery stopped for $regType")
           }
 
           override fun onServiceFound(service: NsdServiceInfo) {
             try {
               // Service discovery success
               if (service.serviceType == serviceType) {
-                // Resolve the service with ad-hoc listener
-                nsdManager.resolveService(service, object : NsdManager.ResolveListener {
-                  override fun onServiceResolved(serviceInfo: NsdServiceInfo) {
-                    try {
-                      resolvedServices[serviceInfo.serviceName] = serviceInfo
-                      sendEvent(SERVICE_FOUND, serviceToMap(serviceInfo))
-                    } catch (e: Exception) {
-                      Log.e(NAME, "Error resolving service", e)
-                    }
-                  }
-
-                  override fun onResolveFailed(
-                    serviceInfo: NsdServiceInfo,
-                    errorCode: Int
-                  ) {
-                    Log.e(NAME, "Resolve failed: $errorCode")
-                  }
-                })
+                // Queue the service for resolution instead of resolving immediately
+                queueServiceForResolve(service)
               }
             } catch (e: Exception) {
-              Log.e(NAME, "Error resolving service", e)
+              Log.e(NAME, "Error queuing service for resolve", e)
             }
           }
 
@@ -101,24 +183,27 @@ class ServiceDiscoveryModule internal constructor(context: ReactApplicationConte
                 sendEvent(SERVICE_LOST, serviceToMap(serviceInfo))
               }
             } catch (e: Exception) {
-              Log.e(NAME, "Error resolving service", e)
+              Log.e(NAME, "Error handling service lost", e)
             }
           }
 
           override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {
+            Log.e(NAME, "Discovery start failed: $errorCode")
             tryStopServiceDiscovery(this)
           }
 
           override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {
+            Log.e(NAME, "Discovery stop failed: $errorCode")
             tryStopServiceDiscovery(this)
           }
         }
       discoveryListeners[serviceType] = discoveryListener
+
       nsdManager.discoverServices(serviceType, NsdManager.PROTOCOL_DNS_SD, discoveryListener)
       promise.resolve(null)
       return
     } catch (e: Exception) {
-      Log.e(NAME, "Error resolving service", e)
+      Log.e(NAME, "Error starting search", e)
       promise.reject(e)
     }
   }
@@ -127,16 +212,23 @@ class ServiceDiscoveryModule internal constructor(context: ReactApplicationConte
   override fun stopSearch(type: String, promise: Promise) {
     try {
       resolvedServices.clear()
+      synchronized(resolveQueue) {
+        resolveQueue.clear()
+        pendingServices.clear()
+        isResolving = false
+      }
+
       val serviceType = getServiceType(type)
       val discoveryListener = discoveryListeners.remove(serviceType)
       if (discoveryListener != null) {
         tryStopServiceDiscovery(discoveryListener)
       }
+
+      promise.resolve(null)
     } catch (e: Exception) {
-      Log.e(NAME, "Error resolving service", e)
+      Log.e(NAME, "Error stopping search", e)
       promise.reject(e)
     }
-
   }
 
   private fun tryStopServiceDiscovery(listener: NsdManager.DiscoveryListener) {
@@ -178,14 +270,8 @@ class ServiceDiscoveryModule internal constructor(context: ReactApplicationConte
       }
       service.putMap("txt", txt)
     } catch (e: Exception) {
-      Log.e(NAME, "Error stopping search", e)
+      Log.e(NAME, "Error converting service to map", e)
     }
     return service
-  }
-
-  companion object {
-    private const val SERVICE_FOUND = "serviceFound"
-    private const val SERVICE_LOST = "serviceLost"
-    const val NAME = "ServiceDiscovery"
   }
 }


### PR DESCRIPTION
**Problem**: Android's NsdManager.resolveService() can only handle one resolve at a time. The library was calling it for every discovered service simultaneously, causing most calls to fail silently with error code 3 (FAILURE_ALREADY_ACTIVE).

**Solution**: Queue discovered services and resolve them one at a time:

```
Before: Service1 → resolve() ❌
Service2 → resolve() ❌  (fails - already resolving)
Service3 → resolve() ❌  (fails - already resolving)

After:  Service1 → queue → resolve() ✓ → wait 50ms
Service2 → queue → resolve() ✓ → wait 50ms
Service3 → queue → resolve() ✓ → wait 50ms
```
This PR adds:

* A queue to hold discovered services
* Sequential processing (one resolve at a time)
* Retry logic for transient failures
* Small delays between resolves